### PR TITLE
Test

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,4 +3,4 @@
 sudo cp bar pawbar /usr/local/bin/
 mkdir -p "$HOME/.config/pawbar/"
 cp kitty.conf "$HOME/.config/pawbar/"
-echo -e "right:\n\t- battery\n\t- space\n\t- sep\n\t- space\n\t- clock" > "$HOME/.config/pawbar/pawbar.yaml"
+echo -e  "right:\n  - battery\n  - space\n  - sep\n  - space\n  - clock" > "$HOME/.config/pawbar/pawbar.yaml"

--- a/internal/services/pulse/pulse.c
+++ b/internal/services/pulse/pulse.c
@@ -6,8 +6,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern void goSinkEventCallback(char* sink, double volume, int mute);
-
 static pa_threaded_mainloop *mloop = NULL;
 static pa_context *context = NULL;
 

--- a/internal/services/pulse/pulse.c
+++ b/internal/services/pulse/pulse.c
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+extern void goSinkEventCallback(char* sink, double volume, int mute);
+
 static pa_threaded_mainloop *mloop = NULL;
 static pa_context *context = NULL;
 

--- a/internal/services/pulse/pulse_api.go
+++ b/internal/services/pulse/pulse_api.go
@@ -81,12 +81,11 @@ func goSinkEventCallback(cSink *C.char, volume C.double, muted C.int) {
 	sinkStr := C.GoString(cSink)
 	if sinkStr == "" || float64(volume) < 0 {
 		go func() {
-			p := PulseService{}
-			s, err := p.GetDefaultSink()
+			s, err := getDefaultSink()
 			if err != nil {
 				return
 			}
-			info, err := p.GetSinkInfo(s)
+			info, err := getSinkInfo(s)
 			if err != nil {
 				return
 			}

--- a/internal/services/pulse/pulse_api.go
+++ b/internal/services/pulse/pulse_api.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 )
 
+
+
 type SinkInfo struct {
 	Volume float64
 	Muted  bool
@@ -74,15 +76,17 @@ func setMute(sink string, mute bool) error {
 
 var sinkEventChan chan SinkEvent
 
+//export goSinkEventCallback
 func goSinkEventCallback(cSink *C.char, volume C.double, muted C.int) {
 	sinkStr := C.GoString(cSink)
 	if sinkStr == "" || float64(volume) < 0 {
 		go func() {
-			s, err := GetDefaultSink()
+			p := PulseService{}
+			s, err := p.GetDefaultSink()
 			if err != nil {
 				return
 			}
-			info, err := GetSinkInfo(s)
+			info, err := p.GetSinkInfo(s)
 			if err != nil {
 				return
 			}

--- a/kitty.conf
+++ b/kitty.conf
@@ -1,4 +1,4 @@
-include /home/harsh/.config/kitty/kitty.conf
+include ${HOME}/.config/kitty/kitty.conf
 
 map kitty_mod+equal  no_op
 map kitty_mod+plus   no_op


### PR DESCRIPTION
- ```go build -buildvcs=false ./cmd/pawbar```

gives error:
```
# github.com/codelif/pawbar/internal/services/pulse
internal/services/pulse/pulse_api.go:81:14: undefined: GetDefaultSink
internal/services/pulse/pulse_api.go:85:17: undefined: GetSinkInfo
```
added in pulse_api.go solution that made it work for me

-
```
 in function 'sink_event_callback_cgo':
(...)/pawbar/internal/services/pulse/pulse.c:215:(.text+0x641): undefined reference to `goSinkEventCallback'
collect2: error: ld returned 1 exit status
```

made changes in pulse_api.go to export

- pawbar.yaml was coming up with extra \ts causing problem 
```
2025/04/07 20:39:48 Panel Size: 192, 1
2025/04/07 20:39:48 Failed to init modules from config: yaml: line 2: found character that cannot start any token
```

- in kitty.conf changed hardcoded path to ${HOME}
```
[0.099] Could not find included config file: /home/harsh/.config/kitty/kitty.conf, ignoring
```