### PR TITLE
Foreground color in Disk,RAM,CPU 

### DIFF
--- a/internal/modules/cpu/cpu.go
+++ b/internal/modules/cpu/cpu.go
@@ -14,8 +14,11 @@ func New() modules.Module {
 }
 
 type CpuModule struct {
-	receive chan bool
-	send    chan modules.Event
+	receive   		chan bool
+	send      		chan modules.Event	
+  highStart     time.Time
+  highTriggered bool
+  required      time.Duration
 }
 
 func (c *CpuModule) Dependencies() []string {
@@ -46,13 +49,33 @@ func (c *CpuModule) Render() []modules.EventCell {
 	if err != nil {
 		return nil
 	}
+	usage:=int(percent[0])
+	const threshold = 90
+
+	if usage > threshold {
+
+		if c.highStart.IsZero() {
+				c.highStart = time.Now()
+		} else if !c.highTriggered && time.Since(c.highStart) >= c.required {
+				c.highTriggered = true
+		}
+
+	} else {
+			c.highStart = time.Time{}
+			c.highTriggered = false
+	}
+
+	s := vaxis.Style{}
+	if(c.highTriggered){
+		s.Foreground=modules.URGENT
+	}
 
 	icon := ''
-	rch := vaxis.Characters(fmt.Sprintf("%c %d%%", icon, int(percent[0])))
+	rch := vaxis.Characters(fmt.Sprintf("%c %d%%", icon, usage ))
 	r := make([]modules.EventCell, len(rch))
 
 	for i, ch := range rch {
-		r[i] = modules.EventCell{C: vaxis.Cell{Character: ch}, Mod: c}
+		r[i] = modules.EventCell{C: vaxis.Cell{Character: ch, Style: s}, Mod: c}
 	}
 	return r
 }

--- a/internal/modules/disk/disk.go
+++ b/internal/modules/disk/disk.go
@@ -83,9 +83,8 @@ func (d *DiskModule) handleMouseEvent(ev vaxis.Mouse) {
 
 }
 
-func (d *DiskModule) formatString() string {
-	du, err := disk.Usage("/")
-	if err != nil {
+func (d *DiskModule) formatString(du *disk.UsageStat) string {
+	if du==nil{
 		return ""
 	}
 
@@ -104,12 +103,24 @@ func (d *DiskModule) formatString() string {
 }
 
 func (d *DiskModule) Render() []modules.EventCell {
+
+	du, err := disk.Usage("/")
+	if err != nil {
+		return nil
+	}
+
+	usage:=int(du.UsedPercent)
+	s:=vaxis.Style{}
+	if usage>95 {
+		s.Foreground= modules.URGENT
+	}
+
 	icon := ''
-	rch := vaxis.Characters(fmt.Sprintf("%c%s", icon, d.formatString()))
+	rch := vaxis.Characters(fmt.Sprintf("%c%s", icon, d.formatString(du)))
 	r := make([]modules.EventCell, len(rch))
 
 	for i, ch := range rch {
-		r[i] = modules.EventCell{C: vaxis.Cell{Character: ch}, Mod: d, MouseShape: vaxis.MouseShapeClickable}
+		r[i] = modules.EventCell{C: vaxis.Cell{Character: ch, Style: s}, Mod: d, MouseShape: vaxis.MouseShapeClickable}
 	}
 	return r
 }

--- a/internal/modules/disk/disk.go
+++ b/internal/modules/disk/disk.go
@@ -113,6 +113,8 @@ func (d *DiskModule) Render() []modules.EventCell {
 	s:=vaxis.Style{}
 	if usage>95 {
 		s.Foreground= modules.URGENT
+	}else if usage>90{
+		s.Foreground= modules.WARNING
 	}
 
 	icon := ''


### PR DESCRIPTION
added .WARNING, .URGENT in ram disk and cpu modules when crossing threshold values:
 * in disk >95 is red, >90 is warning
 * in ram >90 is red, >80 yellow (also default format is percent now hehe sorry)
 * in cpu > 90 is red if it remains >90 for more than 7 secs as cpu flickers quite quick