### PR TITLE
feat(nix): init nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ go.work
 .nfs*
 
 # End of https://www.toptal.com/developers/gitignore/api/go,linux
+
+# Nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "A kitten-panel based desktop panel for your desktop";
+
+  inputs = {
+    self.submodules = true;
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+      {
+        packages.default = pkgs.buildGoModule (finalAttrs: {
+          pname = "pawbar";
+          version = "0-unstable-2025-08-31";
+          src = ./.;
+          subPackages = [ "cmd/pawbar" ];
+          vendorHash = "sha256-5ysy7DGLE99svDPUw1vS05CT7HRcSP1ov27rTqm6a8Y=";
+          buildInputs = with pkgs; [
+            udev
+            librsvg
+            cairo
+          ];
+          nativeBuildInputs = with pkgs; [ pkg-config ];
+        });
+      }
+    );
+}


### PR DESCRIPTION
This PR introduces Nix flake support for building pawbar.

[Nix](https://nixos.org) is a purely functional package manager and build system, widely used for reproducible builds and declarative development environments. By adding a flake.nix, contributors and users can build pawbar with a single command (nix build) across different platforms, without having to manually manage dependencies.