### PR TITLE
fix(docs): fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ It has 16 modules (all customisable upto a certain extent,for now):
 A typical(my) config looks like:
 ```yaml
 left:
-  - hyprws
-  - hyprtitle
+  - ws
+  - title
 
 right:
   - battery


### PR DESCRIPTION
The options don't seem to exist anymore.

```
unknown module '"hyprws"'
unknown module '"hyprtitle"'
 ```